### PR TITLE
Bugfix: Loader not showing

### DIFF
--- a/src/components/Main.vue
+++ b/src/components/Main.vue
@@ -34,16 +34,15 @@ export default {
   created() {
     this.getWebsitesStatus()
       .then(() => {
-
+        this.isLoading = false;
       })
       .catch(() => {
-
+        this.isLoading = false;
       });
   },
   methods: {
     getWebsitesStatus() {
       return new Promise((resolve, reject) => {
-        this.isLoading = false;
         fetch(BASE_URL)
           .then((result) => result.json())
           .then((data) => {


### PR DESCRIPTION
Fixes #4 
Due to missing conditions to set the loading status, the loader did not show appropriately.